### PR TITLE
hotfix/add content type to mp4 upload

### DIFF
--- a/s3-dal/src/s3.repository.ts
+++ b/s3-dal/src/s3.repository.ts
@@ -18,11 +18,13 @@ export class S3Repository {
     bucket: S3Bucket,
     key: string,
     fileContent: Buffer | Uint8Array | Blob | string | ReadStream,
+    mimeType: string,
   ): Promise<PutObjectCommandOutput> {
     const command = new PutObjectCommand({
       Bucket: bucket,
       Key: key,
       Body: fileContent,
+      ContentType: mimeType
     });
 
     return this.s3Client.send(command);

--- a/s3-dal/src/s3.service.ts
+++ b/s3-dal/src/s3.service.ts
@@ -27,6 +27,7 @@ export class S3Service {
         bucket,
         file.originalname,
         fileContent,
+        file.mimetype,
       );
 
       return result.$metadata;


### PR DESCRIPTION
When Asaf and I tried to stream the video, we realized that one of the issues was the s3 uploaded file missing a MIME type.